### PR TITLE
feat: support SHOW_TOPOLOGY

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -16,11 +16,12 @@ package ast
 import (
 	"strings"
 
+	"github.com/pingcap/errors"
+
 	"github.com/arana-db/parser/auth"
 	"github.com/arana-db/parser/format"
 	"github.com/arana-db/parser/model"
 	"github.com/arana-db/parser/mysql"
-	"github.com/pingcap/errors"
 )
 
 var (
@@ -2605,6 +2606,7 @@ const (
 	ShowPlacementForTable
 	ShowPlacementForPartition
 	ShowPlacementLabels
+	ShowTopology
 )
 
 const (
@@ -2688,6 +2690,11 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 	switch n.Tp {
 	case ShowCreateTable:
 		ctx.WriteKeyWord("CREATE TABLE ")
+		if err := n.Table.Restore(ctx); err != nil {
+			return errors.Annotate(err, "An error occurred while restore ShowStmt.Table")
+		}
+	case ShowTopology:
+		ctx.WriteKeyWord("TOPOLOGY FROM ")
 		if err := n.Table.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore ShowStmt.Table")
 		}

--- a/misc.go
+++ b/misc.go
@@ -622,6 +622,7 @@ var tokenMap = map[string]int{
 	"SEND_CREDENTIALS_TO_TIKV": sendCredentialsToTiKV,
 	"SEPARATOR":                separator,
 	"SEQUENCE":                 sequence,
+	"TOPOLOGY":                 topology,
 	"SERIAL":                   serial,
 	"SERIALIZABLE":             serializable,
 	"SESSION":                  session,

--- a/parser.y
+++ b/parser.y
@@ -545,6 +545,7 @@ import (
 	sendCredentialsToTiKV "SEND_CREDENTIALS_TO_TIKV"
 	separator             "SEPARATOR"
 	sequence              "SEQUENCE"
+	topology              "TOPOLOGY"
 	serial                "SERIAL"
 	serializable          "SERIALIZABLE"
 	session               "SESSION"
@@ -6036,6 +6037,7 @@ UnReservedKeyword:
 |	"CYCLE"
 |	"NOCYCLE"
 |	"SEQUENCE"
+|	"TOPOLOGY"
 |	"MAX_MINUTES"
 |	"MAX_IDXNUM"
 |	"PER_TABLE"
@@ -10260,6 +10262,13 @@ ShowStmt:
 			}
 		}
 		$$ = stmt
+	}
+|	"SHOW" "TOPOLOGY" "FROM" TableName
+	{
+		$$ = &ast.ShowStmt{
+			Tp:    ast.ShowTopology,
+			Table: $4.(*ast.TableName),
+		}
 	}
 |	"SHOW" "CREATE" "TABLE" TableName
 	{

--- a/parser_test.go
+++ b/parser_test.go
@@ -3516,6 +3516,9 @@ func TestDDL(t *testing.T) {
 		{"show create placement policy if exists x", false, ""},
 		{"show create placement policy x, y", false, ""},
 		{"show create placement policy `placement`", true, "SHOW CREATE PLACEMENT POLICY `placement`"},
+		// for show topology
+		{"show topology from xxx", true, "SHOW TOPOLOGY FROM `xxx`"},
+		{"show topology from xxx.yyy", true, "SHOW TOPOLOGY FROM `xxx`.`yyy`"},
 		// for create placement policy
 		{"create placement policy x primary_region='us'", true, "CREATE PLACEMENT POLICY `x` PRIMARY_REGION = 'us'"},
 		{"create placement policy x region='us, 3'", false, ""},


### PR DESCRIPTION
Implement `show topology from xxx`, which can be used to list the topology of logical table.

Fix #7 