### PR TITLE
feat: fill param marker order

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -6754,7 +6754,10 @@ SimpleExpr:
 |	Literal
 |	paramMarker
 	{
-		$$ = ast.NewParamMarkerExpr(yyS[yypt].offset)
+		paramExpr := ast.NewParamMarkerExpr(yyS[yypt].offset)
+		paramExpr.SetOrder(parser.paramMarkerCursor)
+		parser.paramMarkerCursor++
+		$$ = paramExpr
 	}
 |	Variable
 |	SumExpr
@@ -8941,7 +8944,10 @@ LimitOption:
 	}
 |	paramMarker
 	{
-		$$ = ast.NewParamMarkerExpr(yyS[yypt].offset)
+		paramExpr := ast.NewParamMarkerExpr(yyS[yypt].offset)
+		paramExpr.SetOrder(parser.paramMarkerCursor)
+		parser.paramMarkerCursor++
+		$$ = paramExpr
 	}
 
 RowOrRows:

--- a/parser_test.go
+++ b/parser_test.go
@@ -6660,3 +6660,19 @@ SELECT 3;
 	assert.Equal(t, []string{"bar", "qux"}, stmts[1].Hints())
 	assert.Len(t, stmts[2].Hints(), 0)
 }
+
+func TestFillParamMarker(t *testing.T) {
+	p := parser.New()
+	stmt, err := p.ParseOneStmt("select * from t where k = ? limit ?,?", "", "")
+	assert.NoError(t, err)
+	sel := stmt.(*ast.SelectStmt)
+
+	where := sel.Where.(*ast.BinaryOperationExpr).R.(*test_driver.ParamMarkerExpr).Order
+	assert.Equal(t, 0, where)
+
+	offset := sel.Limit.Offset.(*test_driver.ParamMarkerExpr).Order
+	assert.Equal(t, 1, offset)
+
+	limit := sel.Limit.Count.(*test_driver.ParamMarkerExpr).Order
+	assert.Equal(t, 2, limit)
+}

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -88,6 +88,7 @@ type Parser struct {
 
 	explicitCharset       bool
 	strictDoubleFieldType bool
+	paramMarkerCursor     int
 
 	// the following fields are used by yyParse to reduce allocation.
 	cache  []yySymType
@@ -125,6 +126,10 @@ func New() *Parser {
 	mode, _ := mysql.GetSQLMode(mysql.DefaultSQLMode)
 	p.SetSQLMode(mode)
 	return p
+}
+
+func (parser *Parser) ParamMarkerCursor() int {
+	return parser.paramMarkerCursor
 }
 
 func (parser *Parser) SetStrictDoubleTypeCheck(val bool) {
@@ -397,6 +402,7 @@ var (
 func resetParams(p *Parser) {
 	p.charset = mysql.DefaultCharset
 	p.collation = mysql.DefaultCollationName
+	p.paramMarkerCursor = 0
 }
 
 // ParseParam represents the parameter of parsing.


### PR DESCRIPTION
Call `SetOrder` for each `ParamMarkerExpr`  automatically when parsing sql.