### PR TITLE
fix: show tables

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -2676,6 +2676,11 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 			ctx.WriteKeyWord("FULL ")
 		}
 	}
+	restoreOptExtended := func() {
+		if n.Extended {
+			ctx.WriteKeyWord("EXTENDED ")
+		}
+	}
 	restoreShowDatabaseNameOpt := func() {
 		if n.DBName != "" {
 			// FROM OR IN
@@ -2905,6 +2910,7 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 		case ShowCharset:
 			ctx.WriteKeyWord("CHARSET")
 		case ShowTables:
+			restoreOptExtended()
 			restoreOptFull()
 			ctx.WriteKeyWord("TABLES")
 			restoreShowDatabaseNameOpt()

--- a/parser.y
+++ b/parser.y
@@ -10352,7 +10352,7 @@ ShowStmt:
 |	"SHOW" "DATABASE" "RULES" "FROM" TableName
 	{
 		$$ = &ast.ShowStmt{
-			Tp:     ast.ShowDatabaseRules,
+			Tp:    ast.ShowDatabaseRules,
 			Table: $5.(*ast.TableName),
 		}
 	}
@@ -10647,6 +10647,15 @@ ShowTargetFilterable:
 			Tp:     ast.ShowTables,
 			DBName: $3,
 			Full:   $1.(bool),
+		}
+	}
+|	"EXTENDED" OptFull "TABLES" ShowDatabaseNameOpt
+	{
+		$$ = &ast.ShowStmt{
+			Tp:       ast.ShowTables,
+			DBName:   $4,
+			Full:     $2.(bool),
+			Extended: true,
 		}
 	}
 |	"OPEN" "TABLES" ShowDatabaseNameOpt

--- a/parser_test.go
+++ b/parser_test.go
@@ -1083,6 +1083,10 @@ func TestDBAStmt(t *testing.T) {
 		{`SHOW FIELDS FROM City;`, true, "SHOW COLUMNS IN `City`"},
 		{`SHOW TRIGGERS LIKE 't'`, true, "SHOW TRIGGERS LIKE _UTF8MB4't'"},
 		{`SHOW DATABASES LIKE 'test2'`, true, "SHOW DATABASES LIKE _UTF8MB4'test2'"},
+		{`SHOW TABLES LIKE 't%'`, true, "SHOW TABLES LIKE _UTF8MB4't%'"},
+		{`SHOW FULL TABLES LIKE 't%'`, true, "SHOW FULL TABLES LIKE _UTF8MB4't%'"},
+		{`SHOW EXTENDED TABLES LIKE 't%'`, true, "SHOW EXTENDED TABLES LIKE _UTF8MB4't%'"},
+		{`SHOW EXTENDED FULL TABLES LIKE 't%'`, true, "SHOW EXTENDED FULL TABLES LIKE _UTF8MB4't%'"},
 		// PROCEDURE and FUNCTION are currently not supported.
 		// And FUNCTION reuse show procedure status process logic.
 		{`SHOW PROCEDURE STATUS WHERE Db='test'`, true, "SHOW PROCEDURE STATUS WHERE `Db`=_UTF8MB4'test'"},


### PR DESCRIPTION
Supports fully compatible syntax parsing with mysql `show tables` statement.
```
SHOW [EXTENDED] [FULL] TABLES
    [{FROM | IN} db_name]
    [LIKE 'pattern' | WHERE expr]
```
ref: https://dev.mysql.com/doc/refman/8.0/en/show-tables.html